### PR TITLE
nhc: coerce datetime + numeric columns in CurrentStorms loader

### DIFF
--- a/src/ocha_lens/datasources/nhc.py
+++ b/src/ocha_lens/datasources/nhc.py
@@ -1104,7 +1104,36 @@ def _process_nhc_to_df(
         return pd.DataFrame(columns=BASE_COLUMNS)
 
     logger.info(f"Extracted {len(all_records)} total records")
-    return pd.DataFrame(all_records)
+    df = pd.DataFrame(all_records)
+    # Coerce datetime columns to naive UTC. Observation rows (from
+    # pd.Timestamp(...Z)) and forecast rows (from dateparser +
+    # relativedelta) can end up with mismatched tz state under some
+    # pandas/dateutil versions, yielding object dtype and breaking
+    # downstream .dt accessors. Normalize to UTC and then drop the tz so
+    # the column is plain datetime64[ns] — matches the storms DB schema
+    # (TIMESTAMP without time zone) and avoids tz-aware/naive comparison
+    # mismatches in downstream filters.
+    for col in ("valid_time", "issued_time"):
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], utc=True).dt.tz_localize(None)
+    # Coerce numeric columns. Forecast points set pd.NA for fields not in
+    # the advisory text (e.g. pressure); mixing pd.NA with floats yields
+    # object dtype, which pandera can't coerce to float64. pd.to_numeric
+    # turns pd.NA into NaN for float columns; Int64 columns get the
+    # nullable-int dtype explicitly so pd.NA is preserved.
+    for col in ("wind_speed", "pressure"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    for col in (
+        "leadtime",
+        "max_wind_radius",
+        "last_closed_isobar_radius",
+        "last_closed_isobar_pressure",
+        "gust_speed",
+    ):
+        if col in df.columns:
+            df[col] = pd.array(df[col], dtype="Int64")
+    return df
 
 
 # Public API Functions
@@ -1546,8 +1575,14 @@ def get_storms(df: pd.DataFrame) -> pd.DataFrame:
 
     df_ = df.copy()
 
-    # Calculate season from valid_time
-    df_["season"] = df_["valid_time"].dt.year
+    # Calculate season from valid_time (coerce via tz-aware UTC and then
+    # drop the tz, in case the column came in as object dtype from mixed
+    # tz-aware / tz-naive rows)
+    df_["season"] = (
+        pd.to_datetime(df_["valid_time"], utc=True)
+        .dt.tz_localize(None)
+        .dt.year
+    )
 
     # Group by atcf_id to get one row per storm
     df_storms = (


### PR DESCRIPTION
## Summary

Fixes ETL failures when loading `CurrentStorms.json` via `lens.nhc.load_nhc()`. Two related dtype problems in `_process_nhc_to_df`:

1. **Datetime tz mismatch.** Observation rows build `valid_time` / `issued_time` from `pd.Timestamp("…Z")` (tz-aware on some pandas/dateutil combinations, tz-naive on others). Forecast rows go through `dateparser.parse(...) + relativedelta + pd.Timestamp(...)`. When the two end up with different tz state, the resulting column is `object` dtype and downstream `.dt.year` (in `get_storms`) raises `AttributeError: Can only use .dt accessor with datetimelike values`.
2. **`pd.NA` + float = object dtype.** Forecast points set `pressure: pd.NA` (no pressure in the advisory text), while the observation row carries a real float. The column becomes `object`, and pandera's `coerce_dtype('float64')` in `TRACK_SCHEMA.validate(...)` raises `SchemaErrors: DATATYPE_COERCION`.

The fix coerces both classes of columns at the bottom of `_process_nhc_to_df`:
- `valid_time` / `issued_time` → `pd.to_datetime(..., utc=True)`
- `wind_speed` / `pressure` → `pd.to_numeric(..., errors="coerce")` (pd.NA → NaN)
- `leadtime`, `max_wind_radius`, `last_closed_isobar_radius`, `last_closed_isobar_pressure`, `gust_speed` → `pd.array(dtype="Int64")` (nullable int, preserves pd.NA)

Also coerces defensively in `get_storms` so a stale caller doesn't reintroduce issue 1.

## Context

Symptom seen on a Databricks scheduled job loading the current single active storm (`EP012026 / Amanda` at the time of debugging). `get_storms` failed first; once that was fixed, `get_tracks` failed next on the same root cause. Both pass with this change. Verified locally + on the same DBX job after bumping the consumer's lens pin.

## Test plan

- [ ] `lens.nhc.load_nhc()` returns a DataFrame where `valid_time` / `issued_time` are `datetime64[ns, UTC]` and `pressure` is `float64`
- [x] `lens.nhc.get_storms(df)` returns rows with a populated `season` column
- [x] `lens.nhc.get_tracks(df)` passes `TRACK_SCHEMA.validate` (no `DATATYPE_COERCION` errors on `pressure`)
- [x] No regression on the existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)