### PR TITLE
docs: GDACS & ADAM datasources + storm utilities (0.5.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,6 @@ the file without committing by executing:
 
 ## Documentation
 
-Documentation
 Documentation is built using Sphinx with MyST for Markdown support. Build the docs locally:
 
 ```bash
@@ -63,3 +62,35 @@ You can also use `sphinx-autobuild` to automatically rebuild the docs on changes
 pip install sphinx-autobuild
 sphinx-autobuild docs docs/_build/html
 ```
+
+## Releasing
+
+The package version is derived from the git tag via `hatch-vcs` — there is
+**no version to bump in `pyproject.toml`**. Creating a GitHub Release is the
+release: the `publish.yaml` workflow fires on `release: published` and
+publishes the build to PyPI. PyPI will not let you reuse a version, so the
+number must be right the first time.
+
+Checklist:
+
+1. **Make sure `main` is green** — CI passing, all intended PRs merged.
+2. **Update the docs for any new/changed public API.** The Sphinx API
+   reference (`docs/api.md`) is manually curated — new functions only appear
+   once they're listed with an `autofunction` directive. For a new
+   datasource, also add a `docs/datasets/<name>.md` page and wire it into
+   `docs/datasets/index.md`. Build locally and confirm it's clean:
+
+   ```bash
+   sphinx-build -b html docs docs/_build/html
+   ```
+
+3. **Pick the version** (semver; the tag *is* the version). On the `0.x`
+   line: bump the minor for new features (e.g. a new datasource or public
+   function), the patch for fixes only. Use a bare tag like `0.5.0` — no `v`
+   prefix.
+4. **Draft release notes** summarizing user-facing changes, grouped by area,
+   referencing the merged PRs.
+5. **Create the GitHub Release** targeting `main` with that tag. This triggers
+   the PyPI publish.
+6. **Verify the publish** — confirm the `publish.yaml` run succeeded and the
+   new version is live on [PyPI](https://pypi.org/project/ocha-lens/).

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,3 +83,76 @@ The `nhc` module provides utilities for downloading, loading, and processing Nat
 ```{eval-rst}
 .. autofunction:: ocha_lens.nhc.get_wsp
 ```
+
+## GDACS Tropical Cyclone Data
+
+The `gdacs` module provides a client for the [GDACS](https://www.gdacs.org/) (Global Disaster Alert and Coordination System) tropical cyclone API: event/episode traversal, advisory timelines, country-level population exposure, and matching GDACS events to NHC `atcf_id`s. No authentication is required.
+
+### Event & Episode Traversal
+
+```{eval-rst}
+.. autofunction:: ocha_lens.gdacs.get_events
+.. autofunction:: ocha_lens.gdacs.get_event_detail
+.. autofunction:: ocha_lens.gdacs.get_episode_detail
+.. autofunction:: ocha_lens.gdacs.latest_episode_id
+.. autofunction:: ocha_lens.gdacs.get_timeline
+```
+
+### Population Exposure
+
+```{eval-rst}
+.. autofunction:: ocha_lens.gdacs.get_exposure_adm0
+.. autofunction:: ocha_lens.gdacs.get_exposure_adm1
+```
+
+### Track Matching
+
+```{eval-rst}
+.. autofunction:: ocha_lens.gdacs.match_to_atcf
+```
+
+### Utility Functions
+
+```{eval-rst}
+.. autofunction:: ocha_lens.gdacs.to_iso3
+```
+
+## ADAM Tropical Cyclone Data
+
+The `adam` module provides access to WFP [ADAM](https://gis.wfp.org/adam/) (Automatic Disaster Analysis and Mapping) tropical cyclone population-exposure data: a paginated event listing and per-event admin-level (ADM0/1/2) exposure.
+
+### Data Loading
+
+```{eval-rst}
+.. autofunction:: ocha_lens.adam.get_events
+.. autofunction:: ocha_lens.adam.get_exposure
+```
+
+### Utility Functions
+
+```{eval-rst}
+.. autofunction:: ocha_lens.adam.make_cumulative
+.. autofunction:: ocha_lens.adam.name_to_iso3
+```
+
+## Storm Utilities
+
+The `utils.storm` module provides shared geometry and matching helpers used across the cyclone datasources, including wind-buffer construction and matching NHC Wind Speed Probability (WSP) polygons to storm tracks.
+
+### Track Interpolation
+
+```{eval-rst}
+.. autofunction:: ocha_lens.utils.storm.interpolate_track
+```
+
+### Wind Buffers
+
+```{eval-rst}
+.. autofunction:: ocha_lens.utils.storm.calculate_wind_buffers_gdf
+```
+
+### WSP–Track Matching
+
+```{eval-rst}
+.. autofunction:: ocha_lens.utils.storm.match_wsp_to_tracks
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,3 +69,7 @@ myst_enable_extensions = [
     "colon_fence",
     "deflist",
 ]
+
+# Auto-generate anchors for headings (h1–h3) so in-page and cross-page
+# section links like `file.md#section-slug` resolve.
+myst_heading_anchors = 3

--- a/docs/datasets/adam.md
+++ b/docs/datasets/adam.md
@@ -1,0 +1,47 @@
+# ADAM Tropical Cyclones
+
+This module provides access to WFP [ADAM](https://gis.wfp.org/adam/) (Automatic Disaster Analysis and Mapping) tropical cyclone population-exposure data. It exposes a paginated event listing and per-event admin-level (ADM0/ADM1/ADM2) population exposure, returned in a long-form, analysis-ready shape.
+
+ADAM uses the same `event_id` as [GDACS](gdacs.md) for the same physical storm, so the two sources join directly on `event_id` — no separate cross-source matching pass is needed.
+
+## Quick Start
+
+### Finding events
+
+```python
+import ocha_lens as lens
+
+# Latest episode per event (cumulative snapshot at storm end), NOAA source
+df_events = lens.adam.get_events(source="NOAA")
+
+# Every episode for every event, over an overlap window
+df_events = lens.adam.get_events(
+    from_date="2024-09-01",
+    to_date="2024-10-15",
+    all_episodes=True,
+)
+```
+
+By default `get_events` de-duplicates to the latest episode per `event_id`. Pass `all_episodes=True` to keep every `(event_id, episode_id)` row, each with its own `population_csv_url`. Date filtering is an **overlap** window (an event is kept if it was active at any point in the range), compared at date granularity.
+
+### Population exposure
+
+```python
+# One event's exposure, long-form across ADM0/ADM1/ADM2 and wind thresholds
+row = df_events.iloc[0]
+df_exposure = lens.adam.get_exposure(
+    event_id=row["event_id"],
+    population_csv_url=row["population_csv_url"],
+)
+```
+
+`get_exposure` downloads the per-episode CSV, converts the per-band counts to cumulative ≥-threshold exposure (for parity with GDACS), aggregates the native ADM2 rows up to ADM1 and ADM0, and maps the country name to ISO3. The result has one row per `(admin_level, admin_unit, wind_speed_kt)`, with `wind_speed_kt` in the standard NHC convention (34/50/64 kt).
+
+## Notes
+
+- **Two CSV schemas:** ADAM has published two column layouts — historical `ADM*_NAME` headers and the newer (2026) `LEVEL_n` headers with embedded `"- TOT"` subtotal rows. Both are handled; the pre-aggregated TOT rows are dropped so they don't double-count into the ADM0/ADM1 aggregates.
+- **Cumulative conversion:** `lens.adam.make_cumulative` is exposed separately if you need the per-band → ≥-threshold transform on your own frame.
+- **ISO3 resolution:** `lens.adam.name_to_iso3` resolves an ADM0 name to ISO3 (override table first, then `pycountry` fuzzy search), returning `None` for genuinely unresolvable names — the `iso3` column is nullable for that reason.
+- **Missing CSVs:** events whose latest episode has no `population_csv_url` raise `NoExposureCSVError`; callers typically skip and retry next cycle.
+
+See the [API reference](../api.md#adam-tropical-cyclone-data) for full function signatures.

--- a/docs/datasets/gdacs.md
+++ b/docs/datasets/gdacs.md
@@ -1,0 +1,58 @@
+# GDACS Tropical Cyclones
+
+This module provides an interface to the [GDACS](https://www.gdacs.org/) (Global Disaster Alert and Coordination System) tropical cyclone API. It exposes event and episode metadata, per-advisory storm timelines, country- and admin-level population exposure, and a function to match a GDACS event to an NHC `atcf_id`. No authentication is required.
+
+GDACS aggregates tropical cyclone advisories from multiple forecasting agencies (NOAA/NHC, JTWC). For storms forecast by the NHC, the GDACS forecast cone is the same underlying forecast as the [NHC data](nhc.md), which is what makes matching a GDACS event to an NHC `atcf_id` possible (see [Matching to NHC](#matching-to-nhc)).
+
+## Quick Start
+
+### Finding events
+
+```python
+import ocha_lens as lens
+
+# Active and recent TC events (all alert levels)
+gdf_events = lens.gdacs.get_events()
+
+# Filter by date range and source
+gdf_events = lens.gdacs.get_events(
+    from_date="2024-09-01",
+    to_date="2024-10-01",
+    source="NOAA",
+)
+```
+
+### Storm timeline
+
+```python
+# Per-advisory snapshots: position, wind speed, and population exposure
+df_timeline = lens.gdacs.get_timeline(eventid=1000123)
+```
+
+Each row is one advisory. The `actual` flag distinguishes observed positions (`"True"`) from forecast-cone positions (`"False"`). `pop39`/`pop74` are instantaneous population snapshots within the 39 kt / 74 kt wind bands — not cumulative.
+
+### Population exposure
+
+```python
+# Cumulative population exposure per wind buffer (~2022 onward)
+adm0 = lens.gdacs.get_exposure_adm0(eventid=1000123)  # {"buffer39": df, "buffer74": df}
+adm1 = lens.gdacs.get_exposure_adm1(eventid=1000123)  # sub-national grain
+```
+
+Each call returns a dict keyed by wind buffer (`"buffer39"`, `"buffer74"`). The `iso3` column carries GDACS' native `GMI_CNTRY` code — apply `lens.gdacs.to_iso3()` to standardize the handful of X-prefixed territory codes to ISO 3166-1 alpha-3.
+
+### Matching to NHC
+
+```python
+# Match a GDACS timeline to an NHC atcf_id
+atcf_id = lens.gdacs.match_to_atcf(df_timeline, nhc_tracks)
+```
+
+`match_to_atcf` votes the GDACS forecast-cone points onto NHC `atcf_id`s by exact `valid_time` (the shared forecast cone agrees to ~0°), with a single-point genesis match as a fallback for completed storms. It returns `None` for non-NHC (JTWC/RSMC) storms. The caller must pass NHC tracks de-duplicated to one row per `(atcf_id, valid_time)` at the freshest issuance — see the function's API reference for the exact contract.
+
+## Notes
+
+- **Coverage:** timelines are available for events from 2015 onward; per-buffer population exposure is available for events from roughly 2022 onward.
+- **Errors:** the module raises explicit exceptions (`NoEpisodesError`, `NoTimelineError`, `EpisodeUrlFormatError`) rather than silently returning empty data, so API-contract changes surface loudly.
+
+See the [API reference](../api.md#gdacs-tropical-cyclone-data) for full function signatures.

--- a/docs/datasets/index.md
+++ b/docs/datasets/index.md
@@ -8,4 +8,6 @@ ocha-lens provides utilities for working with various climate-related datasets:
 ibtracs
 ecmwf_cyclones
 nhc
+gdacs
+adam
 ```

--- a/src/ocha_lens/datasources/gdacs.py
+++ b/src/ocha_lens/datasources/gdacs.py
@@ -46,7 +46,7 @@ _BUFFER_KEYS = ("buffer39", "buffer74")
 # dependencies where GDACS uses an X-prefixed internal code. Add new
 # entries here as new GDACS proprietary codes surface in real data.
 GDACS_PROPRIETARY_TO_ISO3 = {
-    "XJE": "JEY",   # Jersey (British Crown Dependency)
+    "XJE": "JEY",  # Jersey (British Crown Dependency)
     # "XGG": "GGY",  # Guernsey — add if encountered
     # "XIM": "IMN",  # Isle of Man — add if encountered
 }
@@ -62,6 +62,7 @@ def to_iso3(gdacs_country_code: str) -> str:
     return GDACS_PROPRIETARY_TO_ISO3.get(
         gdacs_country_code, gdacs_country_code
     )
+
 
 AlertLevel = Literal["Green", "Orange", "Red"]
 
@@ -460,7 +461,8 @@ def get_timeline(
     # one format from the first row and chokes on the other; format="mixed"
     # parses each value independently.
     df["advisory_datetime"] = pd.to_datetime(
-        df["advisory_datetime"], format="mixed",
+        df["advisory_datetime"],
+        format="mixed",
     )
     df["advisory_number"] = df["advisory_number"].replace("", None)
     df["advisory_number"] = pd.to_numeric(df["advisory_number"])
@@ -518,9 +520,7 @@ def get_exposure_adm0(
         DataFrame with columns ``iso3``, ``country``, ``pop_affected``,
         ``distance_km``.
     """
-    return _exposure_per_buffer(
-        eventid, episodeid, _parse_adm0, detail=detail
-    )
+    return _exposure_per_buffer(eventid, episodeid, _parse_adm0, detail=detail)
 
 
 def get_exposure_adm1(
@@ -550,9 +550,7 @@ def get_exposure_adm1(
         ``admin_type``, ``pop_admin``, ``pop_affected``,
         ``distance_km``.
     """
-    return _exposure_per_buffer(
-        eventid, episodeid, _parse_adm1, detail=detail
-    )
+    return _exposure_per_buffer(eventid, episodeid, _parse_adm1, detail=detail)
 
 
 def _is_actual(actual: pd.Series) -> pd.Series:
@@ -623,8 +621,8 @@ def _match_by_forecast_cone(
     captures — it never needs the genesis cycle, only the cone of
     whatever advisory we did capture.
 
-    Ties (a basin-crossing storm whose cone touches two ``atcf_id``s)
-    go to the earliest ``valid_time``, i.e. the genesis basin.
+    Ties (a basin-crossing storm whose cone touches two ``atcf_id``
+    values) go to the earliest ``valid_time``, i.e. the genesis basin.
     """
     votes = [
         atcf
@@ -694,7 +692,7 @@ def match_to_atcf(
     That asymmetry drives a two-strategy match:
 
     1. :func:`_match_by_forecast_cone` (primary) — vote the GDACS
-       forecast points onto NHC ``atcf_id``s by exact valid_time.
+       forecast points onto NHC ``atcf_id`` values by exact valid_time.
        Robust (many points), product-agnostic, and self-healing for
        storms whose first advisories we never captured.
     2. :func:`_match_by_genesis` (fallback) — single-point match on
@@ -742,9 +740,7 @@ def _exposure_per_buffer(
         # The two args describe different snapshots (event-level vs.
         # a specific episode). Accepting both silently would mean
         # the caller's `detail` is wasted; force them to pick one.
-        raise ValueError(
-            "pass either `episodeid` or `detail`, not both"
-        )
+        raise ValueError("pass either `episodeid` or `detail`, not both")
     if episodeid is not None:
         detail = get_episode_detail(eventid, episodeid)
     elif detail is None:
@@ -787,7 +783,9 @@ def _parse_adm0(data: Dict[str, Any]) -> pd.DataFrame:
                 {
                     "iso3": scalars["GMI_CNTRY"],
                     "country": scalars.get("CNTRY_NAME"),
-                    "pop_affected": _to_nullable_int(scalars.get("POP_AFFECTED")),
+                    "pop_affected": _to_nullable_int(
+                        scalars.get("POP_AFFECTED")
+                    ),
                     "distance_km": _to_nullable_round(scalars.get("distance")),
                 }
             )
@@ -818,7 +816,9 @@ def _parse_adm1(data: Dict[str, Any]) -> pd.DataFrame:
                     "admin_name": scalars.get("ADMIN_NAME"),
                     "admin_type": scalars.get("TYPE_ENG"),
                     "pop_admin": _to_nullable_int(scalars.get("POP_ADMIN")),
-                    "pop_affected": _to_nullable_int(scalars.get("POP_AFFECTED")),
+                    "pop_affected": _to_nullable_int(
+                        scalars.get("POP_AFFECTED")
+                    ),
                     "distance_km": _to_nullable_round(scalars.get("distance")),
                 }
             )

--- a/src/ocha_lens/utils/storm.py
+++ b/src/ocha_lens/utils/storm.py
@@ -396,29 +396,30 @@ def calculate_wind_buffers_gdf(
     quad_cols_format: str = "usa_quadrant_radius_{speed}_{quad}",
     valid_time_col: str = "valid_time",
 ):
-    """
-    Calculate wind buffer polygons for given wind speed quadrants.
-    Note that this function interpolates the storm track to a regular
-    30-minute interval before calculating the wind buffers.
+    """Calculate wind buffer polygons for each wind-speed threshold.
+
+    The storm track is interpolated to a regular 30-minute interval
+    before the per-quadrant wind buffers are built. Reprojection goes
+    through a basin-appropriate ``lon_wrap`` CRS so antimeridian-crossing
+    tracks have continuous longitudes before projecting to Mercator.
+
     Parameters
     ----------
-    df: pd.DataFrame
-        DataFrame with storm track data including quadrant radius columns
-    quad_cols_format: str = 'quadrant_radius_{speed}_{quad}'
-        Format string for quadrant radius columns, with placeholders for
-        speed and quad (e.g., 'quadrant_radius_{speed}_{quad}')
-    lon_col: str = 'Longitude'
-        Name of the longitude column in df
-    lat_col: str = 'Latitude'
-        Name of the latitude column in df
-    valid_time_col: str = 'valid_time'
-        Name of the valid time column in df
+    gdf : gpd.GeoDataFrame
+        Storm track points (EPSG:4326) with per-quadrant radius columns
+        and, optionally, a ``basin`` column used to pick the projection.
+    quad_cols_format : str, default ``"usa_quadrant_radius_{speed}_{quad}"``
+        Format string for the quadrant radius column names, with
+        ``{speed}`` and ``{quad}`` placeholders (quads: ne/se/sw/nw).
+    valid_time_col : str, default ``"valid_time"``
+        Name of the valid-time column used to order and interpolate the
+        track.
 
     Returns
     -------
     gpd.GeoDataFrame
-        GeoDataFrame with wind buffer polygons for each speed
-
+        One row per wind-speed threshold (``wind_speed_kt`` in
+        {34, 50, 64}) with the merged buffer ``geometry`` (EPSG:4326).
     """
     basin = gdf["basin"].iloc[0] if "basin" in gdf.columns else None
     geo_crs = BASIN_GEO_CRS.get(basin, GEO_CRS_MERIDIAN)
@@ -621,6 +622,7 @@ def match_wsp_to_tracks(
     -------
     GeoDataFrame
         Exploded polygon parts with an added ``atcf_id`` column.
+
         - One row per (storm, polygon part) where the track-line intersects
           or containment fallback fires.
         - If a part is intersected by multiple storms' tracks (overlapping


### PR DESCRIPTION
## Summary

Documents the 0.5.0 additions (GDACS & ADAM datasources, storm utilities), which were missing because the Sphinx API reference is manually curated — new functions don't appear until they're explicitly listed.

- **`docs/api.md`**: new **GDACS** section (events/episodes, `get_timeline`, ADM0/ADM1 exposure, `match_to_atcf`, `to_iso3`), **ADAM** section (`get_events`, `get_exposure`, `make_cumulative`, `name_to_iso3`), and a **Storm Utilities** section (`interpolate_track`, `calculate_wind_buffers_gdf`, `match_wsp_to_tracks`).
- **`docs/datasets/gdacs.md`** and **`docs/datasets/adam.md`**: narrative pages (quick-start + notes), wired into the datasets toctree.
- **`docs/conf.py`**: enable `myst_heading_anchors = 3` so in-page / cross-page section links resolve (also fixes a pre-existing broken anchor in `ibtracs.md`).

### Docstring fixes (now rendered publicly)
- `gdacs.match_to_atcf`: invalid `` ``atcf_id``s `` literals (broke rST inline-literal parsing).
- `storm.match_wsp_to_tracks`: missing blank line before the Returns bullet list.
- `storm.calculate_wind_buffers_gdf`: cramped section + stale param names (`df`/`lon_col`/`lat_col`) corrected to match the actual signature.

## Test plan
- [x] `sphinx-build` runs clean — only the pre-existing `_static` warning remains (unrelated; `docs/_static` doesn't exist).
- [ ] Confirm the ReadTheDocs preview renders the new GDACS/ADAM/Storm sections and the cross-page links.
