### PR TITLE
nhc: populate leadtime=0 observation wind radii from advisory

### DIFF
--- a/src/ocha_lens/datasources/nhc.py
+++ b/src/ocha_lens/datasources/nhc.py
@@ -930,6 +930,15 @@ def _parse_current_center_radii(advisory_text: str) -> dict:
     Returns a dict with keys ``quadrant_radius_34/50/64``; each value is a
     ``[NE, SE, SW, NW]`` list (nautical miles), or ``None`` when that threshold
     is absent (e.g. a system below 34 kt).
+
+    An all-zero line (``0NE 0SE 0SW 0NW``) is deliberately kept as
+    ``[0, 0, 0, 0]`` rather than collapsed to ``None``: the realtime
+    observation radii feed track interpolation downstream, where a zero is a
+    usable numeric anchor (it interpolates into a smooth ramp toward the first
+    forecast hour) but ``None`` would become ``NaN`` and contaminate the
+    interpolated buffers. This matches ``_parse_forecast_advisory`` and is the
+    intentional divergence from the ATCF path, which collapses all-zero to
+    ``None``.
     """
     import re
 
@@ -946,20 +955,31 @@ def _parse_current_center_radii(advisory_text: str) -> dict:
     radii_re = re.compile(
         r"^(34|50|64)\s*KT\b\D*?(\d+)\s*NE\s+(\d+)\s*SE\s+(\d+)\s*SW\s+(\d+)\s*NW"
     )
+    # The analysis radii are the FIRST contiguous block of `KT` lines in the
+    # advisory; forecast hours carry their own `34/50/64 KT` lines later. We
+    # capture that first block and stop as soon as it ends, so a later forecast
+    # hour can never overwrite the analysis values (last-match-wins otherwise).
+    # The explicit FORECAST/OUTLOOK VALID check is the primary boundary; the
+    # "stop once the KT block ends" rule is the backstop if NHC ever rewords
+    # those headers.
+    seen_radii = False
     for ln in advisory_text.split("\n"):
         s = ln.strip()
-        # The analysis radii precede the first forecast/outlook block; stop
-        # there so we never pick up a forecast hour's radii.
         if s.startswith("FORECAST VALID") or s.startswith("OUTLOOK VALID"):
             break
         m = radii_re.match(s)
         if m:
+            seen_radii = True
             out[f"quadrant_radius_{m.group(1)}"] = [
                 int(m.group(2)),
                 int(m.group(3)),
                 int(m.group(4)),
                 int(m.group(5)),
             ]
+        elif seen_radii and s:
+            # Passed the end of the analysis KT block (a non-blank, non-radii
+            # line); stop before any forecast-hour radii.
+            break
     return out
 
 

--- a/src/ocha_lens/datasources/nhc.py
+++ b/src/ocha_lens/datasources/nhc.py
@@ -911,6 +911,58 @@ def _parse_forecast_advisory(
     return forecast_points
 
 
+def _parse_current_center_radii(advisory_text: str) -> dict:
+    """Extract the current-center (analysis-time) wind radii from a forecast
+    advisory.
+
+    NHC's ``CurrentStorms.json`` does not carry wind radii for the current
+    observation (see ``_extract_current_observation``), so for realtime data
+    the only source of leadtime=0 radii is the analysis section of the
+    forecast/advisory text — the ``34/50/64 KT...`` lines that appear *before*
+    the first ``FORECAST VALID`` / ``OUTLOOK VALID`` line, e.g.::
+
+        MAX SUSTAINED WINDS 105 KT WITH GUSTS TO 120 KT.
+        64 KT....... 40NE  35SE  30SW  40NW.
+        50 KT....... 90NE  70SE  50SW  80NW.
+        34 KT.......150NE 140SE 100SW 140NW.
+        FORECAST VALID 11/0600Z ...
+
+    Returns a dict with keys ``quadrant_radius_34/50/64``; each value is a
+    ``[NE, SE, SW, NW]`` list (nautical miles), or ``None`` when that threshold
+    is absent (e.g. a system below 34 kt).
+    """
+    import re
+
+    out = {
+        "quadrant_radius_34": None,
+        "quadrant_radius_50": None,
+        "quadrant_radius_64": None,
+    }
+    # <thr> KT <dots/spaces> <NE>NE <SE>SE <SW>SW <NW>NW. Use \D*? (not .*?)
+    # between the threshold and the first radius so the variable run of dots
+    # and spaces is skipped without ever swallowing a digit. This is robust to
+    # the analysis-line spacing ("64 KT....... 40NE") that splits differently
+    # from the forecast-line spacing ("64 KT... 40NE").
+    radii_re = re.compile(
+        r"^(34|50|64)\s*KT\b\D*?(\d+)\s*NE\s+(\d+)\s*SE\s+(\d+)\s*SW\s+(\d+)\s*NW"
+    )
+    for ln in advisory_text.split("\n"):
+        s = ln.strip()
+        # The analysis radii precede the first forecast/outlook block; stop
+        # there so we never pick up a forecast hour's radii.
+        if s.startswith("FORECAST VALID") or s.startswith("OUTLOOK VALID"):
+            break
+        m = radii_re.match(s)
+        if m:
+            out[f"quadrant_radius_{m.group(1)}"] = [
+                int(m.group(2)),
+                int(m.group(3)),
+                int(m.group(4)),
+                int(m.group(5)),
+            ]
+    return out
+
+
 def _fetch_current_storms_json() -> Optional[dict]:
     """
     Fetch current storms JSON from NHC CurrentStorms.json file.
@@ -1047,6 +1099,7 @@ def _process_nhc_to_df(
         logger.debug(f"Processing storm {atcf_id} ({storm_name})")
 
         # Extract current observation
+        obs = None
         if include_observations:
             try:
                 obs = _extract_current_observation(storm)
@@ -1104,6 +1157,23 @@ def _process_nhc_to_df(
                         logger.debug(
                             f"Added {len(forecast_points)} forecast points for {atcf_id}"
                         )
+
+                        # Backfill the leadtime=0 observation's wind radii
+                        # from the advisory's analysis section. CurrentStorms.
+                        # json omits these, so without this the observation
+                        # row has null radii and never yields an observed
+                        # wind buffer downstream.
+                        if obs is not None:
+                            current_radii = _parse_current_center_radii(
+                                advisory_text
+                            )
+                            for col, val in current_radii.items():
+                                if val is not None:
+                                    obs[col] = val
+                            logger.debug(
+                                f"Backfilled current-center radii for {atcf_id}: "
+                                f"{current_radii}"
+                            )
                     else:
                         logger.warning(
                             f"Failed to fetch advisory text for {atcf_id} from {advisory_url}"

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -160,6 +160,44 @@ def test_current_center_radii_absent():
     }
 
 
+def test_current_center_radii_stops_at_block_end_without_marker():
+    """Backstop: even if the FORECAST VALID/OUTLOOK VALID header were reworded,
+    the parser stops at the end of the first contiguous KT block, so a later
+    forecast-hour KT line can't overwrite the analysis radii."""
+    text = (
+        "NWS NATIONAL HURRICANE CENTER MIAMI FL       AL012026\n"
+        "MAX SUSTAINED WINDS 105 KT WITH GUSTS TO 120 KT.\n"
+        "64 KT....... 40NE  35SE  30SW  40NW.\n"
+        "50 KT....... 90NE  70SE  50SW  80NW.\n"
+        "34 KT.......150NE 140SE 100SW 140NW.\n"
+        "12 FT SEAS..120NE 150SE 120SW  90NW.\n"
+        # No "FORECAST VALID" marker here — simulate a header reword.
+        "SOMETHING ELSE 11/0600Z 25.0N 70.0W\n"
+        "MAX WIND 100 KT...GUSTS 120 KT.\n"
+        "64 KT....... 50NE  45SE  40SW  50NW.\n"
+    )
+    radii = _parse_current_center_radii(text)
+    # Analysis value kept; the later 50NE forecast-hour radius did not leak in.
+    assert radii["quadrant_radius_64"] == [40, 35, 30, 40]
+
+
+def test_current_center_radii_all_zero_kept():
+    """An all-zero analysis line is kept as [0, 0, 0, 0], not collapsed to
+    None, so it remains a usable numeric anchor for downstream interpolation."""
+    text = (
+        "NWS NATIONAL HURRICANE CENTER MIAMI FL       AL012026\n"
+        "MAX SUSTAINED WINDS 65 KT WITH GUSTS TO 80 KT.\n"
+        "64 KT.......  0NE   0SE   0SW   0NW.\n"
+        "50 KT.......  0NE   0SE   0SW   0NW.\n"
+        "34 KT....... 90NE  90SE  60SW  70NW.\n"
+        "FORECAST VALID 11/0600Z 25.0N 70.0W\n"
+    )
+    radii = _parse_current_center_radii(text)
+    assert radii["quadrant_radius_64"] == [0, 0, 0, 0]
+    assert radii["quadrant_radius_50"] == [0, 0, 0, 0]
+    assert radii["quadrant_radius_34"] == [90, 90, 60, 70]
+
+
 def test_observation_backfills_radii_from_advisory(monkeypatch):
     """End-to-end: the leadtime=0 observation (from CurrentStorms.json, which
     omits radii) is enriched with the advisory's analysis-time wind radii."""

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from ocha_lens.datasources.nhc import (
     _parse_atcf_adeck,
+    _parse_current_center_radii,
     _parse_forecast_advisory,
     get_storms,
     get_tracks,
@@ -113,3 +114,87 @@ def test_forecast_advisory_wrong_id():
     )
 
     assert len(forecast_points) == 0
+
+
+def test_current_center_radii_parsing():
+    """Current-center (analysis-time) radii are read from the advisory's
+    section preceding the first FORECAST VALID line. CurrentStorms.json omits
+    these, so this is the only realtime source of leadtime=0 wind radii."""
+    with open(FIXTURES_PATH / "TCM_example.txt", "r") as f:
+        advisory_text = f.read()
+
+    radii = _parse_current_center_radii(advisory_text)
+
+    # From the analysis block of the Lee advisory (lines "64/50/34 KT...").
+    assert radii["quadrant_radius_64"] == [40, 35, 30, 40]
+    assert radii["quadrant_radius_50"] == [90, 70, 50, 80]
+    assert radii["quadrant_radius_34"] == [150, 140, 100, 140]
+
+
+def test_current_center_radii_stops_before_forecast():
+    """Radii from the first FORECAST VALID hour must not leak into the
+    current-center result (the 34 KT forecast[0] line is 150/140/100/140 too,
+    so assert the 64 KT value, which differs: analysis 40NE vs forecast 50NE)."""
+    with open(FIXTURES_PATH / "TCM_example.txt", "r") as f:
+        advisory_text = f.read()
+
+    radii = _parse_current_center_radii(advisory_text)
+    # Analysis 64 KT NE radius is 40; the first forecast hour's is 50.
+    assert radii["quadrant_radius_64"][0] == 40
+
+
+def test_current_center_radii_absent():
+    """A system with no 34/50/64 KT analysis lines yields all-None."""
+    text_no_radii = (
+        "NWS NATIONAL HURRICANE CENTER MIAMI FL       EP992026\n"
+        "TROPICAL DEPRESSION CENTER LOCATED NEAR 12.0N 100.0W AT 09/1500Z\n"
+        "MAX SUSTAINED WINDS 25 KT WITH GUSTS TO 35 KT.\n"
+        "FORECAST VALID 10/0000Z 13.0N 101.0W\n"
+        "MAX WIND 30 KT...GUSTS 40 KT.\n"
+    )
+    radii = _parse_current_center_radii(text_no_radii)
+    assert radii == {
+        "quadrant_radius_34": None,
+        "quadrant_radius_50": None,
+        "quadrant_radius_64": None,
+    }
+
+
+def test_observation_backfills_radii_from_advisory(monkeypatch):
+    """End-to-end: the leadtime=0 observation (from CurrentStorms.json, which
+    omits radii) is enriched with the advisory's analysis-time wind radii."""
+    import ocha_lens.datasources.nhc as nhc
+
+    with open(FIXTURES_PATH / "TCM_example.txt", "r") as f:
+        advisory_text = f.read()
+    monkeypatch.setattr(
+        nhc, "_fetch_forecast_advisory", lambda url: advisory_text
+    )
+
+    raw = {
+        "activeStorms": [
+            {
+                "id": "al132023",
+                "name": "Lee",
+                "lastUpdate": "2023-09-10T21:00:00Z",
+                "intensity": "105",
+                "pressure": "954",
+                "latitudeNumeric": 22.1,
+                "longitudeNumeric": -61.7,
+                "forecastAdvisory": {
+                    "url": "http://example/advisory",
+                    "issuance": "2023-09-10T21:00:00Z",
+                },
+            }
+        ]
+    }
+
+    df = nhc._process_nhc_to_df(
+        raw, include_observations=True, include_forecasts=True
+    )
+    obs = df[df.leadtime == 0].iloc[0]
+    # Backfilled from the advisory analysis block, NOT the first forecast hour
+    # (whose 64 KT NE radius is 50, vs the analysis 40).
+    assert obs["quadrant_radius_34"] == [150, 140, 100, 140]
+    assert obs["quadrant_radius_50"] == [90, 70, 50, 80]
+    assert obs["quadrant_radius_64"] == [40, 35, 30, 40]


### PR DESCRIPTION
## Problem

Realtime-ingested NHC storms get **no observed wind radii** on their `leadtime=0` points, even when they're tropical-storm/hurricane strength. Surfaced in `ds-storms-pipeline`: every 2026 EP storm (Amanda, Boris, Cristina — all reached 40 kt) has zero observed wind buffers, because observed buffers require a non-null `quadrant_radius_*` and all realtime `leadtime=0` rows are null.

## Root cause

`_extract_current_observation()` builds the `leadtime=0` row from `CurrentStorms.json`, which **does not carry wind radii**, so it hardcodes:

```python
"quadrant_radius_34": None,  # Not available in CurrentStorms.json
"quadrant_radius_50": None,
"quadrant_radius_64": None,
```

Forecast points (from the parsed advisory) get radii fine; archive/A-deck ingestion was unaffected because OFCL `tau=0` records include radii. Only the realtime observation path was missing them.

## Fix

The current radii **are** in the forecast/advisory text we already fetch — in the analysis block before the first `FORECAST VALID` line:

```
MAX SUSTAINED WINDS 105 KT WITH GUSTS TO 120 KT.
64 KT....... 40NE  35SE  30SW  40NW.
50 KT....... 90NE  70SE  50SW  80NW.
34 KT.......150NE 140SE 100SW 140NW.
FORECAST VALID 11/0600Z ...
```

The existing parser reads these into `radii_*` but then discards them (no preceding `FORECAST VALID` point to attach to). This PR adds `_parse_current_center_radii()` and backfills the radii onto the `leadtime=0` observation in `_process_nhc_to_df`.

Parsing uses a tolerant regex (`\D*?` between threshold and radii) rather than positional tokens, because the analysis lines tokenize differently from forecast lines — `64 KT....... 40NE` → `['64','KT','.','40NE',...]` (a stray `.` token) vs `64 KT... 40NE` → `['64','KT','40NE',...]`. The regex handles both.

## Tests

- `_parse_current_center_radii`: present / stops-before-forecast / absent (sub-34kt system)
- end-to-end: `_process_nhc_to_df` enriches the `leadtime=0` observation with the analysis radii (asserts the 64 KT value is the analysis `40NE`, not the first forecast hour's `50NE`)

All 12 NHC tests pass; ruff clean.

## Downstream

After release, bump the pin in `ds-storms-pipeline` and backfill 2026 storms to generate the missing observed wind buffers.